### PR TITLE
document problem and work around when needing different passwords

### DIFF
--- a/vault_from_gpg_agent.py
+++ b/vault_from_gpg_agent.py
@@ -27,6 +27,11 @@
 # Note that the path to this script is used as the cache key for this
 # password in gpg-agent.  For example, if you move this script to a
 # new path then you may be re-prompted for your password.
+#
+# Also, if you need to work with different passwords for different sets
+# of vaults, then your best bet currently is probably to have different
+# copies of this script, one for each set of vaults so that each set
+# has a different cache key.
 
 import subprocess
 import sys


### PR DESCRIPTION
I propose to document the problem and the work around when using different sets of vaults, each with set with its distinct password. Such a situation may arise when maintaining multiple ansible playbooks for different customers each with a different password.

The proposed workaround is of course a disgusting hack. One improvement to this ugly hack could maybe be to replace `my_path = os.path.realpath(sys.argv[0])` [in line 72](https://github.com/dsedivec/ansible-plugins/blob/826d0eaccc24932217efd3f6d75db4619b6ede4d/vault_from_gpg_agent.py#L72) with `my_path = os.path.abspath(sys.argv[0])` which would not do symlink resolution and thus allow something like this:

```
ls -l ansible-tools
lrwxrwxrwx 1 user group  6 Nov 12 09:00 vault_from_gpg_agent_customer_1.py -> vault_from_gpg_agent.py
lrwxrwxrwx 1 user group  6 Nov 12 09:00 vault_from_gpg_agent_customer_2.py -> vault_from_gpg_agent.py
lrwxrwxrwx 1 user group  6 Nov 12 09:00 vault_from_gpg_agent_customer_3.py -> vault_from_gpg_agent.py
-rwxr-xr-x 1 user group 78 Nov 12 09:00 vault_from_gpg_agent.py
```

But this also makes we wince, so it's maybe just a *little* improvement.

The real problem IMHO is that [ansible-vault calls the external password script](https://github.com/ansible/ansible/blob/aee7a3ed6809c93a81307466503eec630a343d9e/lib/ansible/parsing/vault/__init__.py#L454) without any parameters whatsoever, and so the password script is completely blind (I mean it doesn't even get to know which `vault-id`' is being used!) and thus can't do any intelligent decision.

So maybe the right (and heroic) thing to do would be to move the discussion upstream and have the problem fixed there for good and for real by having `ansible-vault` pass all the necessary context to the external password script?